### PR TITLE
Add College Basketball (CBB) with March Madness bracket view

### DIFF
--- a/api/calculator.js
+++ b/api/calculator.js
@@ -58,6 +58,10 @@ export async function analyzeGameEntertainment(game, sport = 'NFL') {
       overtime: excitement.overtimeDetected ?? game.overtime,
       bowlName: game.bowlName,
       playoffRound: game.playoffRound,
+      homeSeed: game.homeSeed,
+      awaySeed: game.awaySeed,
+      bracketRound: game.bracketRound,
+      bracketRegion: game.bracketRegion,
       dataQuality: dataQuality.hasIssues ? {
         warning: true,
         severity: dataQuality.severity,
@@ -93,6 +97,10 @@ export async function analyzeGameEntertainmentDetailed(game, sport = 'NFL') {
       overtime: game.overtime,
       bowlName: game.bowlName,
       playoffRound: game.playoffRound,
+      homeSeed: game.homeSeed,
+      awaySeed: game.awaySeed,
+      bracketRound: game.bracketRound,
+      bracketRegion: game.bracketRegion,
       ...excitement,
       dataQuality: dataQuality.hasIssues ? {
         warning: true,

--- a/api/calculator.js
+++ b/api/calculator.js
@@ -155,7 +155,7 @@ function calculateExcitementDetailed(probabilities, game, sport = 'NFL') {
     const marginFloor = calculateMarginBasedTensionFloor(margin, sport, lateCloseness);
     tensionScore = Math.max(tensionScore, marginFloor);
   }
-  const blowoutThreshold = sport === 'NBA'
+  const blowoutThreshold = (sport === 'NBA' || sport === 'CBB')
     ? SCORING_CONFIG.thresholds.blowoutMargin.nba
     : sport === 'MLB'
     ? SCORING_CONFIG.thresholds.blowoutMargin.mlb
@@ -243,7 +243,7 @@ function calculateExcitementDetailed(probabilities, game, sport = 'NFL') {
 
   // Hard margin cap for extreme blowouts (data quality guardrail)
   if (margin != null) {
-    const blowoutCapThreshold = sport === 'NBA' ? 22 : sport === 'MLB' ? 12 : 28;
+    const blowoutCapThreshold = (sport === 'NBA' || sport === 'CBB') ? 22 : sport === 'MLB' ? 12 : 28;
     if (margin > blowoutCapThreshold) {
       return {
         score: Math.min(finalScore, 6.5),
@@ -700,7 +700,7 @@ function calculateCloseGameBonus(game, sport, finishScore = 0, tensionScore = 0)
   const config = SCORING_CONFIG.bonuses.closeGame;
 
   // Adjust thresholds for basketball (higher scoring)
-  const factor = sport === 'NBA' ? 2 : 1; // MLB uses factor 1 (low-scoring like football)
+  const factor = (sport === 'NBA' || sport === 'CBB') ? 2 : 1; // Basketball uses factor 2 (higher scoring)
 
   let baseBonus = 0;
   if (margin <= 3 * factor) {
@@ -752,7 +752,7 @@ function calculateMarginBasedTensionFloor(margin, sport, lateCloseness = null) {
   const config = SCORING_CONFIG.thresholds.tensionFloor;
   if (!config) return 0;
 
-  const factor = sport === 'NBA' ? config.nbaMultiplier : (sport === 'MLB' ? (config.mlbMultiplier || 1) : 1);
+  const factor = (sport === 'NBA' || sport === 'CBB') ? config.nbaMultiplier : (sport === 'MLB' ? (config.mlbMultiplier || 1) : 1);
   let floor = 0;
 
   if (margin <= config.oneScore.margin * factor) {
@@ -1194,7 +1194,7 @@ function applyMarginCorrection(normalizedScore, margin, sport, tensionScore, dra
   if (residual >= 0) return { ...noCorrection, marginPredicted, residual };
 
   // Sport-adjusted maximum margin for correction eligibility
-  const f = sport === 'NBA' ? 2 : 1; // MLB uses f=1 (low-scoring like football)
+  const f = (sport === 'NBA' || sport === 'CBB') ? 2 : 1; // Basketball uses f=2 (higher scoring)
   const maxCloseMargin = config.maxCloseMargin * f;
   if (margin > maxCloseMargin) return { ...noCorrection, marginPredicted, residual };
 

--- a/api/data-quality.js
+++ b/api/data-quality.js
@@ -70,7 +70,7 @@ export function detectDataQualityIssues(probs, game, sport = 'NFL') {
     const leadChanges = countLeadChanges(probs);
 
     // Sport-specific thresholds for "close game"
-    const closeThreshold = sport === 'NBA' ? 10 : sport === 'MLB' ? 4 : 7;
+    const closeThreshold = (sport === 'NBA' || sport === 'CBB') ? 10 : sport === 'MLB' ? 4 : 7;
 
     if (margin <= closeThreshold && leadChanges === 0) {
       issues.push({
@@ -81,7 +81,7 @@ export function detectDataQualityIssues(probs, game, sport = 'NFL') {
     }
 
     // Also flag if a one-possession game has very few lead changes
-    const onePossessionThreshold = sport === 'NBA' ? 3 : sport === 'MLB' ? 2 : 3;
+    const onePossessionThreshold = (sport === 'NBA' || sport === 'CBB') ? 3 : sport === 'MLB' ? 2 : 3;
     if (margin <= onePossessionThreshold && leadChanges <= 1) {
       // Only flag if not already flagged for 0 lead changes
       if (leadChanges === 1) {
@@ -119,7 +119,7 @@ export function detectDataQualityIssues(probs, game, sport = 'NFL') {
 
   // Issue 4: Sparse data points
   // Full games typically have 400-600 data points; sparse data may miss drama
-  const minExpectedPoints = sport === 'NBA' ? 200 : sport === 'MLB' ? 100 : 150;
+  const minExpectedPoints = (sport === 'NBA' || sport === 'CBB') ? 200 : sport === 'MLB' ? 100 : 150;
   if (probs.length < minExpectedPoints) {
     issues.push({
       type: 'sparse-data',

--- a/api/fetcher.js
+++ b/api/fetcher.js
@@ -11,6 +11,9 @@ export async function fetchGames(sport, season, week, seasonType = '2', date = n
     if (sport === 'MLB') {
       return await fetchMLBGames(date);
     }
+    if (sport === 'CBB') {
+      return await fetchCBBGames(date);
+    }
 
     // Handle NFL/CFB week-based fetching
     const league = sport === 'CFB' ? 'college-football' : 'nfl';
@@ -118,6 +121,45 @@ async function fetchNBAGames(date) {
   return games.filter(game => game.completed);
 }
 
+export async function fetchMarchMadnessGames(season) {
+  // Fetch all NCAA tournament games for a season
+  // Tournament typically runs mid-March through early April
+  const year = season + 1; // CBB season 2025 means 2025-26, tournament in March 2026
+  const startDate = `${year}0301`;
+  const endDate = `${year}0415`;
+
+  const url = `https://site.api.espn.com/apis/site/v2/sports/basketball/mens-college-basketball/scoreboard?dates=${startDate}-${endDate}&seasontype=3&groups=100&limit=200`;
+
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`March Madness API error: ${response.status}`);
+
+  const data = await response.json();
+
+  const games = (data.events || []).map(event => parseEvent(event, 'CBB'));
+  return games; // Return all games including incomplete ones for bracket display
+}
+
+async function fetchCBBGames(date) {
+  let targetDate = date;
+  if (!targetDate) {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    targetDate = yesterday.toISOString().split('T')[0].replace(/-/g, '');
+  } else if (targetDate.includes('-')) {
+    targetDate = targetDate.replace(/-/g, '');
+  }
+
+  const url = `https://site.api.espn.com/apis/site/v2/sports/basketball/mens-college-basketball/scoreboard?dates=${targetDate}&groups=100&limit=100`;
+
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`CBB API error: ${response.status}`);
+
+  const data = await response.json();
+
+  const games = (data.events || []).map(event => parseEvent(event, 'CBB'));
+  return games.filter(game => game.completed);
+}
+
 async function fetchMLBGames(date) {
   let targetDate = date;
   if (!targetDate) {
@@ -203,6 +245,35 @@ function parseEvent(event, sport = 'NFL', nflPlayoffRound = null) {
     }
   }
 
+  // Parse CBB tournament data (seeds and bracket round)
+  let homeSeed = null;
+  let awaySeed = null;
+  let bracketRound = null;
+  let bracketRegion = null;
+
+  if (sport === 'CBB') {
+    homeSeed = homeTeam?.curatedRank?.current ?? homeTeam?.seed ?? null;
+    awaySeed = awayTeam?.curatedRank?.current ?? awayTeam?.seed ?? null;
+
+    // Try to get bracket round from competition or notes
+    if (competition.bracketRound) {
+      bracketRound = competition.bracketRound.name || null;
+    }
+    // Fall back to notes headline for round info
+    const notes = competition.notes || [];
+    if (notes.length > 0) {
+      const headline = notes[0]?.headline || '';
+      if (!bracketRound && headline) {
+        bracketRound = headline;
+      }
+      // Extract region from headline (e.g., "NCAA Tournament - South Region - First Round")
+      const regionMatch = headline.match(/(South|East|West|Midwest)\s+Region/i);
+      if (regionMatch) {
+        bracketRegion = regionMatch[1];
+      }
+    }
+  }
+
   return {
     id: event.id,
     homeTeam: homeTeam?.team?.shortDisplayName || homeTeam?.team?.displayName || 'Unknown',
@@ -213,7 +284,11 @@ function parseEvent(event, sport = 'NFL', nflPlayoffRound = null) {
     overtime: overtime,
     date: event.date || competition.date,
     bowlName: bowlName,
-    playoffRound: playoffRound
+    playoffRound: playoffRound,
+    homeSeed: homeSeed,
+    awaySeed: awaySeed,
+    bracketRound: bracketRound,
+    bracketRegion: bracketRegion
   };
 }
 
@@ -237,6 +312,8 @@ export async function fetchSingleGame(sport, gameId) {
       apiPath = 'basketball/nba';
     } else if (sport === 'MLB') {
       apiPath = 'baseball/mlb';
+    } else if (sport === 'CBB') {
+      apiPath = 'basketball/mens-college-basketball';
     } else {
       throw new Error('Invalid sport');
     }

--- a/api/games.js
+++ b/api/games.js
@@ -25,7 +25,7 @@ export default async function handler(req, res) {
 
     // Handle March Madness tournament request
     if (sport === 'CBB' && tournamentMode) {
-      console.log(`Fetching March Madness bracket for season ${season || window?.selectedSeason}`);
+      console.log(`Fetching March Madness bracket for season ${season || 'default'}`);
 
       const tournamentSeason = season || new Date().getFullYear() - 1;
       const games = await fetchMarchMadnessGames(tournamentSeason);

--- a/api/games.js
+++ b/api/games.js
@@ -1,5 +1,5 @@
 // Streamlined Games API Endpoint
-import { fetchGames, fetchSingleGame } from './fetcher.js';
+import { fetchGames, fetchSingleGame, fetchMarchMadnessGames } from './fetcher.js';
 import { analyzeGameEntertainment } from './calculator.js';
 import { NFL_PLAYOFF_ROUNDS, isNFLPlayoffRound } from '../shared/algorithm-config.js';
 
@@ -21,7 +21,44 @@ export default async function handler(req, res) {
   }
 
   try {
-    const { sport = 'NFL', season, week, seasonType = '2', date, gameId } = req.body;
+    const { sport = 'NFL', season, week, seasonType = '2', date, gameId, tournamentMode } = req.body;
+
+    // Handle March Madness tournament request
+    if (sport === 'CBB' && tournamentMode) {
+      console.log(`Fetching March Madness bracket for season ${season || window?.selectedSeason}`);
+
+      const tournamentSeason = season || new Date().getFullYear() - 1;
+      const games = await fetchMarchMadnessGames(tournamentSeason);
+      const completedGames = games.filter(g => g.completed);
+
+      if (!completedGames || completedGames.length === 0) {
+        return res.status(200).json({
+          success: true,
+          games: [],
+          metadata: { sport, tournamentMode: true, count: 0 }
+        });
+      }
+
+      console.log(`Found ${completedGames.length} completed tournament games, analyzing...`);
+
+      const analyzedGames = await Promise.all(
+        completedGames.map(game => analyzeGameEntertainment(game, sport))
+      );
+
+      const validGames = analyzedGames.filter(game => game !== null);
+      validGames.sort((a, b) => (b.excitement || 0) - (a.excitement || 0));
+
+      return res.status(200).json({
+        success: true,
+        games: validGames,
+        metadata: {
+          sport,
+          tournamentMode: true,
+          count: validGames.length,
+          totalGames: analyzedGames.length
+        }
+      });
+    }
 
     // Handle single game request
     if (gameId) {
@@ -67,7 +104,7 @@ export default async function handler(req, res) {
       actualSeasonType = '3';
     }
 
-    if (sport === 'NBA' || sport === 'MLB') {
+    if (sport === 'NBA' || sport === 'MLB' || sport === 'CBB') {
       console.log(`Fetching ${sport} games for ${date || 'yesterday'}`);
     } else if (week === 'bowls') {
       console.log(`Fetching ${sport} bowl games for ${season} season`);

--- a/api/teams.js
+++ b/api/teams.js
@@ -31,6 +31,8 @@ export default async function handler(req, res) {
       apiPath = 'basketball/nba';
     } else if (sport === 'MLB') {
       apiPath = 'baseball/mlb';
+    } else if (sport === 'CBB') {
+      apiPath = 'basketball/mens-college-basketball';
     } else {
       return res.status(400).json({
         success: false,

--- a/scripts/generate-static.js
+++ b/scripts/generate-static.js
@@ -113,7 +113,7 @@ function validateOptions() {
     process.exit(1);
   }
 
-  if (options.sport === 'NBA' || options.sport === 'MLB') {
+  if (options.sport === 'NBA' || options.sport === 'MLB' || options.sport === 'CBB') {
     if (!options.all && !options.date) {
       console.error(`Error: ${options.sport} requires either --date or --all`);
       printUsage();
@@ -134,7 +134,7 @@ function getStaticFilePath(sport, season, weekOrDate) {
   const dir = join(PUBLIC_DATA_DIR, sportLower, String(season));
 
   let filename;
-  if (sport === 'NBA' || sport === 'MLB') {
+  if (sport === 'NBA' || sport === 'MLB' || sport === 'CBB') {
     filename = `${weekOrDate}.json`;
   } else {
     let weekStr;
@@ -157,6 +157,7 @@ function getStaticFilePath(sport, season, weekOrDate) {
 function getSummaryPath(sport) {
   if (sport === 'NBA') return 'basketball/nba';
   if (sport === 'MLB') return 'baseball/mlb';
+  if (sport === 'CBB') return 'basketball/mens-college-basketball';
   if (sport === 'CFB') return 'football/college-football';
   return 'football/nfl';
 }
@@ -230,7 +231,7 @@ async function generateStatic(sport, season, weekOrDate) {
       seasonType = '3';
     }
 
-    if (sport === 'NBA' || sport === 'MLB') {
+    if (sport === 'NBA' || sport === 'MLB' || sport === 'CBB') {
       games = await fetchGames(sport, season, null, seasonType, weekOrDate);
     } else {
       games = await fetchGames(sport, season, weekOrDate, seasonType);
@@ -268,7 +269,7 @@ async function generateStatic(sport, season, weekOrDate) {
       source: 'ESPN Win Probability Analysis'
     };
 
-    if (sport === 'NBA' || sport === 'MLB') {
+    if (sport === 'NBA' || sport === 'MLB' || sport === 'CBB') {
       metadata.date = weekOrDate;
     } else {
       metadata.week = weekOrDate;
@@ -422,13 +423,13 @@ async function main() {
   console.log(`\n🏈 Game Excitement Tracker - Static Data Generator\n`);
 
   if (options.all) {
-    if (options.sport === 'NBA' || options.sport === 'MLB') {
+    if (options.sport === 'NBA' || options.sport === 'MLB' || options.sport === 'CBB') {
       await generateAllNBADates(options.season);
     } else {
       await generateAllWeeks(options.sport, options.season);
     }
   } else {
-    const weekOrDate = (options.sport === 'NBA' || options.sport === 'MLB') ? options.date : options.week;
+    const weekOrDate = (options.sport === 'NBA' || options.sport === 'MLB' || options.sport === 'CBB') ? options.date : options.week;
     await generateStatic(options.sport, options.season, weekOrDate);
   }
 

--- a/shared/algorithm-config.js
+++ b/shared/algorithm-config.js
@@ -69,7 +69,8 @@ export const ALGORITHM_CONFIG = {
       NFL: { mustWatch: 8.3, recommended: 6.0 },
       CFB: { mustWatch: 7.7, recommended: 5.8 },
       NBA: { mustWatch: 8.5, recommended: 6.5 },
-      MLB: { mustWatch: 8.5, recommended: 6.5 }
+      MLB: { mustWatch: 8.5, recommended: 6.5 },
+      CBB: { mustWatch: 8.5, recommended: 6.5 }
     }
   },
 
@@ -118,7 +119,8 @@ export const ALGORITHM_CONFIG = {
     blowoutMargin: {
       nflCfb: 21,
       nba: 18,
-      mlb: 8
+      mlb: 8,
+      cbb: 20
     },
     competitiveBand: {
       low: 0.30,
@@ -216,7 +218,8 @@ export const ALGORITHM_CONFIG = {
         NFL: { intercept: 8.37, slope: -0.199 },
         CFB: { intercept: 7.13, slope: -0.114 },
         NBA: { intercept: 9.00, slope: -0.178 },
-        MLB: { intercept: 9.00, slope: -0.178 }
+        MLB: { intercept: 9.00, slope: -0.178 },
+        CBB: { intercept: 9.00, slope: -0.178 }
       },
       // Maximum margin (sport-adjusted) eligible for correction
       // Beyond this, margin is too large for ESPN overconfidence to be the issue

--- a/shared/espn-api.js
+++ b/shared/espn-api.js
@@ -15,6 +15,9 @@ export function resolveSportLeague(sport) {
   if (sport === 'MLB') {
     return { sportType: 'baseball', league: 'mlb' };
   }
+  if (sport === 'CBB') {
+    return { sportType: 'basketball', league: 'mens-college-basketball' };
+  }
   return {
     sportType: 'football',
     league: sport === 'CFB' ? 'college-football' : 'nfl'

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -1432,3 +1432,156 @@
             margin-top: 12px;
             line-height: 1.5;
         }
+
+        /* ===== March Madness Bracket ===== */
+
+        .bracket-back {
+            margin-bottom: 24px;
+        }
+
+        .bracket-back-link {
+            font-size: 11px;
+            color: var(--text-secondary);
+            text-decoration: underline;
+            letter-spacing: 0.05em;
+        }
+
+        .bracket-back-link:hover {
+            color: var(--text-primary);
+        }
+
+        .bracket-container {
+            display: flex;
+            gap: 24px;
+            overflow-x: auto;
+            padding-bottom: 16px;
+        }
+
+        .bracket-round {
+            min-width: 200px;
+            flex-shrink: 0;
+        }
+
+        .bracket-round-header {
+            font-size: 11px;
+            font-weight: 500;
+            color: var(--text-secondary);
+            text-transform: lowercase;
+            letter-spacing: 0.05em;
+            margin-bottom: 16px;
+            padding-bottom: 8px;
+            border-bottom: 1px solid var(--border-secondary);
+        }
+
+        .bracket-round-games {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .bracket-region-label {
+            font-size: 9px;
+            font-weight: 500;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            margin-top: 8px;
+            margin-bottom: 4px;
+        }
+
+        .bracket-region-label:first-child {
+            margin-top: 0;
+        }
+
+        .bracket-matchup {
+            display: flex;
+            flex-direction: column;
+            border: 1px solid var(--border-secondary);
+            border-radius: 2px;
+            position: relative;
+            padding-right: 36px;
+        }
+
+        .bracket-matchup:hover {
+            border-color: var(--border-primary);
+        }
+
+        .bracket-team {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 8px;
+            font-size: 12px;
+            color: var(--text-secondary);
+            transition: all 150ms ease;
+        }
+
+        .bracket-team:first-child {
+            border-bottom: 1px solid var(--border-secondary);
+        }
+
+        .bracket-team.winner {
+            color: var(--text-primary);
+            font-weight: 500;
+        }
+
+        .bracket-seed {
+            font-size: 10px;
+            color: var(--text-muted);
+            min-width: 22px;
+            font-variant-numeric: tabular-nums;
+        }
+
+        .bracket-name {
+            flex: 1;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .bracket-team-score {
+            font-size: 11px;
+            font-variant-numeric: tabular-nums;
+            min-width: 20px;
+            text-align: right;
+        }
+
+        .bracket-gei {
+            position: absolute;
+            right: 0;
+            top: 0;
+            bottom: 0;
+            width: 32px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 10px;
+            font-weight: 600;
+            border-left: 1px solid var(--border-secondary);
+            font-variant-numeric: tabular-nums;
+        }
+
+        .bracket-gei.must-watch {
+            color: var(--accent-must-watch);
+        }
+
+        .bracket-gei.recommended {
+            color: var(--accent-recommended);
+        }
+
+        .bracket-gei.skip {
+            color: var(--text-muted);
+        }
+
+        /* Bracket responsive */
+        @media (max-width: 768px) {
+            .bracket-container {
+                flex-direction: column;
+                gap: 32px;
+            }
+
+            .bracket-round {
+                min-width: unset;
+                width: 100%;
+            }
+        }

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Game Entertainment Index</title>
-    <meta name="description" content="Ranks NFL, CFB, NBA, and MLB games by entertainment value using win probability data. Find the best games to watch without spoilers.">
+    <meta name="description" content="Ranks NFL, CFB, NBA, MLB, and CBB games by entertainment value using win probability data. Find the best games to watch without spoilers.">
     <meta name="author" content="Matthew Silverman">
     <!-- SheetJS library for Excel export -->
     <script src="https://cdn.sheetjs.com/xlsx-0.20.1/package/dist/xlsx.full.min.js"></script>
@@ -47,9 +47,13 @@
                         <span class="separator">·</span>
                         <span class="sport-option active" data-sport="MLB" id="mlbOption">mlb<span class="beta-label">beta</span></span>
                         <span class="separator">·</span>
+                        <span class="sport-option" data-sport="CBB" id="cbbOption">cbb<span class="beta-label">beta</span></span>
+                        <span class="separator">·</span>
                         <span class="find-game-link" id="findGameLink">find a game</span>
                         <span class="separator">·</span>
                         <span class="find-game-link" id="topGamesLink">top games</span>
+                        <span class="separator bracket-only" id="bracketSeparator" style="display: none;">·</span>
+                        <span class="find-game-link bracket-only" id="bracketLink" style="display: none;">march madness</span>
 
                         <!-- Team Picker Dropdown -->
                         <div class="team-picker" id="teamPicker">
@@ -202,6 +206,7 @@
                     <option value="CFB">CFB</option>
                     <option value="NBA">NBA</option>
                     <option value="MLB">MLB</option>
+                    <option value="CBB">CBB</option>
                 </select>
             </div>
 

--- a/src/index.html
+++ b/src/index.html
@@ -52,9 +52,6 @@
                         <span class="find-game-link" id="findGameLink">find a game</span>
                         <span class="separator">·</span>
                         <span class="find-game-link" id="topGamesLink">top games</span>
-                        <span class="separator bracket-only" id="bracketSeparator" style="display: none;">·</span>
-                        <span class="find-game-link bracket-only" id="bracketLink" style="display: none;">march madness</span>
-
                         <!-- Team Picker Dropdown -->
                         <div class="team-picker" id="teamPicker">
                             <input type="text" class="team-search-input" placeholder="search teams..." id="teamSearchInput">
@@ -90,6 +87,8 @@
                         <span class="current-selection" id="currentDateDisplay">yesterday</span>
                         <span class="separator">·</span>
                         <a href="#" class="week-nav-link" id="nextDate"><span id="nextDateDisplay"></span> →</a>
+                        <span class="separator" id="bracketSeparator" style="display: none;">·</span>
+                        <a href="#" class="week-nav-link" id="bracketLink" style="display: none;">march madness</a>
 
                         <!-- Custom Date Picker Dropdown -->
                         <div class="date-picker" id="customDatePicker">

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -130,17 +130,6 @@ window.getTier = getTier;
             document.getElementById('mlbOption').classList.toggle('active', window.selectedSport === 'MLB');
             document.getElementById('cbbOption').classList.toggle('active', window.selectedSport === 'CBB');
 
-            // Show/hide March Madness bracket link
-            const bracketLink = document.getElementById('bracketLink');
-            const bracketSeparator = document.getElementById('bracketSeparator');
-            if (window.selectedSport === 'CBB') {
-                bracketLink.style.display = 'inline';
-                bracketSeparator.style.display = 'inline';
-            } else {
-                bracketLink.style.display = 'none';
-                bracketSeparator.style.display = 'none';
-            }
-
             // Clean up top games state when returning to normal view
             document.getElementById('topGamesSelector').style.display = 'none';
             document.getElementById('topGamesLink').classList.remove('active');
@@ -150,9 +139,21 @@ window.getTier = getTier;
                 document.getElementById('weekSelector').style.display = 'none';
                 document.getElementById('dateSelector').style.display = 'block';
                 updateDateNavigation();
+
+                // Show March Madness link only for CBB
+                const bracketLink = document.getElementById('bracketLink');
+                const bracketSeparator = document.getElementById('bracketSeparator');
+                const isCBB = window.selectedSport === 'CBB';
+                bracketLink.style.display = isCBB ? 'inline' : 'none';
+                bracketSeparator.style.display = isCBB ? 'inline' : 'none';
+                if (isCBB) {
+                    bracketLink.textContent = window.viewMode === 'bracket' ? '← back to dates' : 'march madness';
+                }
             } else {
                 document.getElementById('weekSelector').style.display = 'block';
                 document.getElementById('dateSelector').style.display = 'none';
+                document.getElementById('bracketLink').style.display = 'none';
+                document.getElementById('bracketSeparator').style.display = 'none';
                 updateWeekNavigation();
             }
         }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -13,6 +13,7 @@ import {
     updateDateNavigation
 } from './utils/dates.js';
 import { loadGames } from './services/api.js';
+import { openBracketView, closeBracketView } from './components/bracket.js';
 import { displayResults, calculatePeriodAverages, createGameRow, attachScoreToggleListener, attachRadarChartListeners } from './components/game-list.js';
 import { renderRadarChart, attachMetricHoverListeners } from './components/radar-chart.js';
 import { populateCustomDatePicker } from './components/date-picker.js';
@@ -127,6 +128,18 @@ window.getTier = getTier;
             document.getElementById('cfbOption').classList.toggle('active', window.selectedSport === 'CFB');
             document.getElementById('nbaOption').classList.toggle('active', window.selectedSport === 'NBA');
             document.getElementById('mlbOption').classList.toggle('active', window.selectedSport === 'MLB');
+            document.getElementById('cbbOption').classList.toggle('active', window.selectedSport === 'CBB');
+
+            // Show/hide March Madness bracket link
+            const bracketLink = document.getElementById('bracketLink');
+            const bracketSeparator = document.getElementById('bracketSeparator');
+            if (window.selectedSport === 'CBB') {
+                bracketLink.style.display = 'inline';
+                bracketSeparator.style.display = 'inline';
+            } else {
+                bracketLink.style.display = 'none';
+                bracketSeparator.style.display = 'none';
+            }
 
             // Clean up top games state when returning to normal view
             document.getElementById('topGamesSelector').style.display = 'none';
@@ -490,6 +503,34 @@ window.getTier = getTier;
                 }
             });
 
+            document.getElementById('cbbOption').addEventListener('click', () => {
+                if (window.selectedSport !== 'CBB') {
+                    window.periodAverages = null;
+                    window.selectedSport = 'CBB';
+                    window.selectedSeason = getCurrentWeek('CBB').season;
+                    window.selectedDate = getDefaultNBADate();
+
+                    window.pickerMonth = null;
+                    window.pickerYear = null;
+                    window.allTeams = [];
+                    window.viewMode = 'week';
+                    window.selectedTeam = null;
+                    window.isInitialLoad = true;
+                    updateUI();
+                    loadGames();
+                }
+            });
+
+            // March Madness bracket link
+            document.getElementById('bracketLink').addEventListener('click', (e) => {
+                e.preventDefault();
+                if (window.viewMode === 'bracket') {
+                    closeBracketView();
+                } else {
+                    openBracketView();
+                }
+            });
+
             // Custom date picker toggle (date-based sports)
             document.getElementById('currentDateDisplay').addEventListener('click', (e) => {
                 if (isDateBasedSport(window.selectedSport)) {
@@ -755,6 +796,8 @@ window.getTier = getTier;
         window.closeExportModal = closeExportModal;
         window.openTopGames = openTopGames;
         window.closeTopGames = closeTopGames;
+        window.openBracketView = openBracketView;
+        window.closeBracketView = closeBracketView;
         window.loadGames = loadGames;
         window.showLoading = showLoading;
         window.showEmpty = showEmpty;

--- a/src/js/components/bracket.js
+++ b/src/js/components/bracket.js
@@ -44,10 +44,21 @@ function normalizeRegion(regionStr) {
 export async function openBracketView() {
     window.viewMode = 'bracket';
 
-    // Update UI state
-    document.getElementById('bracketLink').classList.add('active');
-    document.getElementById('dateSelector').style.display = 'none';
+    // Update date selector to show bracket mode
+    document.getElementById('dateSelector').style.display = 'block';
     document.getElementById('weekSelector').style.display = 'none';
+    document.getElementById('prevDate').style.display = 'none';
+    document.getElementById('nextDate').style.display = 'none';
+    // Hide the separators around the date nav arrows
+    const dateSeps = document.getElementById('dateSelector').querySelectorAll(':scope > .separator');
+    dateSeps.forEach(sep => {
+        if (sep.id !== 'bracketSeparator') sep.style.display = 'none';
+    });
+    document.getElementById('currentDateDisplay').textContent = `march madness ${window.selectedSeason + 1}`;
+    const bracketLink = document.getElementById('bracketLink');
+    bracketLink.style.display = 'inline';
+    bracketLink.textContent = '← back to dates';
+    document.getElementById('bracketSeparator').style.display = 'inline';
 
     // Update header
     document.getElementById('headerWeekInfo').textContent = `March Madness ${window.selectedSeason + 1}`;
@@ -125,7 +136,15 @@ export async function openBracketView() {
  */
 export function closeBracketView() {
     window.viewMode = 'week';
-    document.getElementById('bracketLink').classList.remove('active');
+
+    // Restore date navigation elements
+    document.getElementById('prevDate').style.display = '';
+    document.getElementById('nextDate').style.display = '';
+    const dateSeps = document.getElementById('dateSelector').querySelectorAll(':scope > .separator');
+    dateSeps.forEach(sep => {
+        if (sep.id !== 'bracketSeparator') sep.style.display = '';
+    });
+
     window.updateUI();
     window.loadGames();
 }
@@ -186,8 +205,6 @@ function renderBracket(games) {
         </div>
     `;
 
-    // Back link
-    html += `<div class="bracket-back"><a href="#" class="bracket-back-link" id="bracketBackLink">← back to games</a></div>`;
 
     // Bracket container
     html += '<div class="bracket-container">';
@@ -244,12 +261,6 @@ function renderBracket(games) {
     html += '</div>';
 
     document.getElementById('resultsArea').innerHTML = html;
-
-    // Attach event listeners
-    document.getElementById('bracketBackLink')?.addEventListener('click', (e) => {
-        e.preventDefault();
-        closeBracketView();
-    });
 
     // Score toggle
     const scoreToggle = document.getElementById('scoreToggle');

--- a/src/js/components/bracket.js
+++ b/src/js/components/bracket.js
@@ -72,10 +72,8 @@ export async function openBracketView() {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 sport: 'CBB',
-                date: startDate,
-                tournamentMode: true,
-                startDate: startDate,
-                endDate: endDate
+                season: season,
+                tournamentMode: true
             })
         });
 

--- a/src/js/components/bracket.js
+++ b/src/js/components/bracket.js
@@ -1,0 +1,306 @@
+/**
+ * March Madness Bracket Component
+ * Displays NCAA tournament games in a bracket visualization
+ */
+
+// Round display order and labels
+const ROUNDS = [
+    { key: 'First Round', short: 'R64', order: 1 },
+    { key: 'Second Round', short: 'R32', order: 2 },
+    { key: 'Sweet 16', short: 'S16', order: 3 },
+    { key: 'Elite Eight', short: 'E8', order: 4 },
+    { key: 'Final Four', short: 'F4', order: 5 },
+    { key: 'Championship', short: 'Final', order: 6 }
+];
+
+// Normalize ESPN round names to our standard keys
+function normalizeRound(roundStr) {
+    if (!roundStr) return null;
+    const lower = roundStr.toLowerCase();
+    if (lower.includes('first round') || lower.includes('round of 64') || lower.includes('1st round')) return 'First Round';
+    if (lower.includes('second round') || lower.includes('round of 32') || lower.includes('2nd round')) return 'Second Round';
+    if (lower.includes('sweet 16') || lower.includes('sweet sixteen') || lower.includes('regional semifinal')) return 'Sweet 16';
+    if (lower.includes('elite eight') || lower.includes('elite 8') || lower.includes('regional final')) return 'Elite Eight';
+    if (lower.includes('final four') || lower.includes('national semifinal')) return 'Final Four';
+    if (lower.includes('championship') || lower.includes('national championship') || lower.includes('title game')) return 'Championship';
+    // Try to detect from "NCAA Tournament" prefix
+    if (lower.includes('first four')) return null; // Skip First Four
+    return null;
+}
+
+const REGIONS = ['South', 'East', 'Midwest', 'West'];
+
+function normalizeRegion(regionStr) {
+    if (!regionStr) return null;
+    for (const r of REGIONS) {
+        if (regionStr.toLowerCase().includes(r.toLowerCase())) return r;
+    }
+    return null;
+}
+
+/**
+ * Open the bracket view - fetches tournament data and renders bracket
+ */
+export async function openBracketView() {
+    window.viewMode = 'bracket';
+
+    // Update UI state
+    document.getElementById('bracketLink').classList.add('active');
+    document.getElementById('dateSelector').style.display = 'none';
+    document.getElementById('weekSelector').style.display = 'none';
+
+    // Update header
+    document.getElementById('headerWeekInfo').textContent = `March Madness ${window.selectedSeason + 1}`;
+
+    window.showLoading('loading march madness bracket...');
+
+    try {
+        // Fetch bracket games via API
+        const season = window.selectedSeason;
+        const year = season + 1;
+        const startDate = `${year}-03-01`;
+        const endDate = `${year}-04-15`;
+
+        // Fetch games day by day through the tournament window
+        const allGames = [];
+        const start = new Date(startDate);
+        const end = new Date(endDate);
+
+        // Try fetching from API with tournament params
+        const response = await fetch('/api/games', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                sport: 'CBB',
+                date: startDate,
+                tournamentMode: true,
+                startDate: startDate,
+                endDate: endDate
+            })
+        });
+
+        const data = await response.json();
+        if (data.success && data.games) {
+            allGames.push(...data.games);
+        }
+
+        // If API didn't return tournament data, try fetching date by date
+        if (allGames.length === 0) {
+            // Fetch recent tournament dates
+            for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+                const dateStr = d.toISOString().split('T')[0];
+                try {
+                    const resp = await fetch('/api/games', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ sport: 'CBB', date: dateStr })
+                    });
+                    const dayData = await resp.json();
+                    if (dayData.success && dayData.games) {
+                        // Tag games with their bracket metadata
+                        dayData.games.forEach(g => {
+                            if (g.bracketRound || g.bracketRegion) {
+                                allGames.push(g);
+                            }
+                        });
+                    }
+                } catch (e) {
+                    // Skip failed dates
+                }
+            }
+        }
+
+        if (allGames.length === 0) {
+            window.showEmpty('No March Madness games found yet. Check back once tournament games have been played.');
+            return;
+        }
+
+        renderBracket(allGames);
+    } catch (error) {
+        console.error('Error loading bracket:', error);
+        window.showEmpty('Could not load March Madness bracket. Please try again.');
+    }
+}
+
+/**
+ * Close the bracket view and return to normal date-based view
+ */
+export function closeBracketView() {
+    window.viewMode = 'week';
+    document.getElementById('bracketLink').classList.remove('active');
+    window.updateUI();
+    window.loadGames();
+}
+
+/**
+ * Render the bracket visualization
+ */
+function renderBracket(games) {
+    // Classify games by round
+    const byRound = {};
+    const byRegion = {};
+
+    games.forEach(game => {
+        const round = normalizeRound(game.bracketRound);
+        if (!round) return;
+
+        if (!byRound[round]) byRound[round] = [];
+        byRound[round].push(game);
+
+        const region = normalizeRegion(game.bracketRegion);
+        if (region) {
+            if (!byRegion[region]) byRegion[region] = {};
+            if (!byRegion[region][round]) byRegion[region][round] = [];
+            byRegion[region][round].push(game);
+        }
+    });
+
+    // Sort games within each round by seed matchup
+    Object.values(byRound).forEach(roundGames => {
+        roundGames.sort((a, b) => {
+            const seedA = Math.min(a.homeSeed || 99, a.awaySeed || 99);
+            const seedB = Math.min(b.homeSeed || 99, b.awaySeed || 99);
+            return seedA - seedB;
+        });
+    });
+
+    // Build HTML
+    let html = '';
+
+    // Stats line
+    const totalGames = games.filter(g => normalizeRound(g.bracketRound)).length;
+    const mustWatch = games.filter(g => normalizeRound(g.bracketRound) && window.getTier(g.excitement || 0, 'CBB')?.cssClass === 'must-watch').length;
+    const recommended = games.filter(g => normalizeRound(g.bracketRound) && window.getTier(g.excitement || 0, 'CBB')?.cssClass === 'recommended').length;
+
+    html += `<div class="statistics-line">
+        <span class="stat-number">${totalGames}</span> tournament games ·
+        <span class="stat-number">${mustWatch}</span> must watch ·
+        <span class="stat-number">${recommended}</span> recommended
+    </div>`;
+
+    // Spoiler toggle
+    html += `
+        <div class="spoiler-toggle-wrapper">
+            <span class="toggle-label">show scores</span>
+            <div class="toggle-switch ${!window.spoilerFree ? 'active' : ''}" id="scoreToggle">
+                <div class="toggle-slider"></div>
+            </div>
+        </div>
+    `;
+
+    // Back link
+    html += `<div class="bracket-back"><a href="#" class="bracket-back-link" id="bracketBackLink">← back to games</a></div>`;
+
+    // Bracket container
+    html += '<div class="bracket-container">';
+
+    // Render round by round
+    const activeRounds = ROUNDS.filter(r => byRound[r.key] && byRound[r.key].length > 0);
+
+    if (activeRounds.length === 0) {
+        html += '<div class="empty-message">No completed tournament games found.</div>';
+    } else {
+        activeRounds.forEach(round => {
+            const roundGames = byRound[round.key] || [];
+            html += `<div class="bracket-round">`;
+            html += `<div class="bracket-round-header">${round.key}</div>`;
+            html += `<div class="bracket-round-games">`;
+
+            // Group by region within each round
+            const regions = {};
+            roundGames.forEach(game => {
+                const region = normalizeRegion(game.bracketRegion) || 'Other';
+                if (!regions[region]) regions[region] = [];
+                regions[region].push(game);
+            });
+
+            // For Final Four and Championship, don't show region headers
+            const showRegions = round.order <= 4 && Object.keys(regions).length > 1;
+
+            if (showRegions) {
+                REGIONS.forEach(regionName => {
+                    const regionGames = regions[regionName];
+                    if (!regionGames || regionGames.length === 0) return;
+
+                    html += `<div class="bracket-region-label">${regionName}</div>`;
+                    regionGames.forEach(game => {
+                        html += renderMatchup(game);
+                    });
+                });
+                // Handle games without a region
+                if (regions['Other'] && regions['Other'].length > 0) {
+                    regions['Other'].forEach(game => {
+                        html += renderMatchup(game);
+                    });
+                }
+            } else {
+                roundGames.forEach(game => {
+                    html += renderMatchup(game);
+                });
+            }
+
+            html += `</div></div>`;
+        });
+    }
+
+    html += '</div>';
+
+    document.getElementById('resultsArea').innerHTML = html;
+
+    // Attach event listeners
+    document.getElementById('bracketBackLink')?.addEventListener('click', (e) => {
+        e.preventDefault();
+        closeBracketView();
+    });
+
+    // Score toggle
+    const scoreToggle = document.getElementById('scoreToggle');
+    if (scoreToggle) {
+        scoreToggle.addEventListener('click', () => {
+            window.spoilerFree = !window.spoilerFree;
+            localStorage.setItem('spoilerFree', window.spoilerFree);
+            renderBracket(games); // Re-render with new spoiler state
+        });
+    }
+}
+
+/**
+ * Render a single matchup in the bracket
+ */
+function renderMatchup(game) {
+    const score = game.excitement || 0;
+    const tier = window.getTier(score, 'CBB');
+    const tierClass = tier.cssClass;
+    const displayScore = score % 1 === 0 ? score : score.toFixed(1);
+
+    const shouldShowScores = !window.spoilerFree;
+
+    const homeSeed = game.homeSeed ? `(${game.homeSeed})` : '';
+    const awaySeed = game.awaySeed ? `(${game.awaySeed})` : '';
+
+    const homeWon = game.completed && game.homeScore > game.awayScore;
+    const awayWon = game.completed && game.awayScore > game.homeScore;
+
+    const homeScoreText = shouldShowScores ? game.homeScore : '';
+    const awayScoreText = shouldShowScores ? game.awayScore : '';
+    const otText = shouldShowScores && game.overtime ? ' OT' : '';
+
+    const geiDisplay = shouldShowScores ? displayScore : '?';
+    const geiClass = shouldShowScores ? tierClass : 'skip';
+
+    return `
+        <div class="bracket-matchup">
+            <div class="bracket-team ${awayWon && shouldShowScores ? 'winner' : ''}">
+                <span class="bracket-seed">${awaySeed}</span>
+                <span class="bracket-name">${game.awayTeam}</span>
+                <span class="bracket-team-score">${awayScoreText}</span>
+            </div>
+            <div class="bracket-team ${homeWon && shouldShowScores ? 'winner' : ''}">
+                <span class="bracket-seed">${homeSeed}</span>
+                <span class="bracket-name">${game.homeTeam}</span>
+                <span class="bracket-team-score">${homeScoreText}</span>
+            </div>
+            <div class="bracket-gei ${geiClass}">${geiDisplay}${otText}</div>
+        </div>
+    `;
+}

--- a/src/js/components/bracket.js
+++ b/src/js/components/bracket.js
@@ -283,8 +283,8 @@ function renderMatchup(game) {
     const awayScoreText = shouldShowScores ? game.awayScore : '';
     const otText = shouldShowScores && game.overtime ? ' OT' : '';
 
-    const geiDisplay = shouldShowScores ? displayScore : '?';
-    const geiClass = shouldShowScores ? tierClass : 'skip';
+    const geiDisplay = displayScore;
+    const geiClass = tierClass;
 
     return `
         <div class="bracket-matchup">

--- a/src/js/components/export-modal.js
+++ b/src/js/components/export-modal.js
@@ -85,6 +85,15 @@ export function getWeekRangePresets(sport) {
             { label: 'Second Half', value: 'second-half', start: `${season}-07-16`, end: `${season}-10-31` },
             { label: 'Custom', value: 'custom', start: null, end: null }
         ];
+    } else if (sport === 'CBB') {
+        const currentSeasonInfo = getCurrentWeek('CBB');
+        const season = currentSeasonInfo.season;
+        return [
+            { label: 'All', value: 'all', start: `${season}-11-01`, end: `${season + 1}-04-10` },
+            { label: 'Regular Season', value: 'regular', start: `${season}-11-01`, end: `${season + 1}-03-15` },
+            { label: 'March Madness', value: 'march-madness', start: `${season + 1}-03-16`, end: `${season + 1}-04-10` },
+            { label: 'Custom', value: 'custom', start: null, end: null }
+        ];
     }
     return [];
 }
@@ -195,6 +204,9 @@ export function handlePresetSelection(sport, preset) {
             if (sport === 'MLB') {
                 exportStartDate.value = `${season}-03-20`;
                 exportEndDate.value = `${season}-10-31`;
+            } else if (sport === 'CBB') {
+                exportStartDate.value = `${season}-11-01`;
+                exportEndDate.value = `${season + 1}-04-10`;
             } else {
                 exportStartDate.value = `${season}-10-01`;
                 exportEndDate.value = `${season + 1}-04-30`;
@@ -400,8 +412,8 @@ export function getRangeInfo(sport, rangeStart, rangeEnd) {
         // Check if it's a partial season by comparing dates
         const currentSeasonInfo = getCurrentWeek(sport);
         const season = currentSeasonInfo.season;
-        const defaultStart = sport === 'MLB' ? `${season}-03-20` : `${season}-10-01`;
-        const defaultEnd = sport === 'MLB' ? `${season}-10-31` : `${season + 1}-04-30`;
+        const defaultStart = sport === 'MLB' ? `${season}-03-20` : sport === 'CBB' ? `${season}-11-01` : `${season}-10-01`;
+        const defaultEnd = sport === 'MLB' ? `${season}-10-31` : sport === 'CBB' ? `${season + 1}-04-10` : `${season + 1}-04-30`;
 
         if (rangeStart && rangeEnd && (rangeStart !== defaultStart || rangeEnd !== defaultEnd)) {
             isPartial = true;
@@ -463,7 +475,7 @@ export async function fetchAllWeeks(sport, season, rangeStart = null, rangeEnd =
         // Date-based sports use date fetching
         useDateBasedFetch = true;
         // Use provided date range or default to season start - Today
-        const defaultStartMonth = sport === 'MLB' ? 2 : 9; // March for MLB, October for NBA
+        const defaultStartMonth = sport === 'MLB' ? 2 : sport === 'CBB' ? 10 : 9; // March for MLB, November for CBB, October for NBA
         const startDate = rangeStart ? new Date(rangeStart) : new Date(season, defaultStartMonth, 1);
         const endDate = rangeEnd ? new Date(rangeEnd) : new Date();
         const daysDiff = Math.floor((endDate - startDate) / (24 * 60 * 60 * 1000));
@@ -680,8 +692,8 @@ export async function exportFullSeason() {
         // Generate filename with range info
         const rangeInfo = getRangeInfo(sport, rangeStart, rangeEnd);
         let filename;
-        if (sport === 'NBA') {
-            filename = `gei-nba-${season}-${season + 1}-${rangeInfo.filenameSuffix}.xlsx`;
+        if (sport === 'NBA' || sport === 'CBB') {
+            filename = `gei-${sport.toLowerCase()}-${season}-${season + 1}-${rangeInfo.filenameSuffix}.xlsx`;
         } else if (sport === 'MLB') {
             filename = `gei-mlb-${season}-${rangeInfo.filenameSuffix}.xlsx`;
         } else {

--- a/src/js/components/game-list.js
+++ b/src/js/components/game-list.js
@@ -127,6 +127,8 @@ export function createGameRow(game, index) {
         sportPath = 'nba';
     } else if (window.selectedSport === 'MLB') {
         sportPath = 'mlb';
+    } else if (window.selectedSport === 'CBB') {
+        sportPath = 'mens-college-basketball';
     }
     const recapUrl = `https://www.espn.com/${sportPath}/game/_/gameId/${game.id}`;
 

--- a/src/js/components/radar-chart.js
+++ b/src/js/components/radar-chart.js
@@ -88,7 +88,7 @@ export function renderRadarChart(breakdown, averages = null) {
         `;
     });
 
-    const legendLabel = (window.selectedSport === 'NBA' || window.selectedSport === 'MLB') ? 'Date avg' : 'Week avg';
+    const legendLabel = (window.selectedSport === 'NBA' || window.selectedSport === 'MLB' || window.selectedSport === 'CBB') ? 'Date avg' : 'Week avg';
     const legend = hasAverages ? `
         <div class="radar-legend">
             <div class="radar-legend-item">

--- a/src/js/utils/dates.js
+++ b/src/js/utils/dates.js
@@ -1,7 +1,7 @@
 import { NFL_PLAYOFF_ROUNDS, getNFLPlayoffRoundKeys } from '../../../shared/algorithm-config.js';
 
 export function isDateBasedSport(sport) {
-  return sport === 'NBA' || sport === 'MLB';
+  return sport === 'NBA' || sport === 'MLB' || sport === 'CBB';
 }
 
 export function addDays(date, days) {
@@ -103,6 +103,14 @@ export function getCurrentWeek(sport) {
     return info;
   }
 
+  if (sport === 'CBB') {
+    // CBB season runs October-April (like NBA)
+    const season = month >= 9 ? year : year - 1;
+    const info = { season: season, week: 1 };
+    console.log('🏀 getCurrentWeek(CBB):', info);
+    return info;
+  }
+
   return { season: year, week: 1 };
 }
 
@@ -159,7 +167,8 @@ const CACHE_TTL = {
   NFL: 24 * 60 * 60 * 1000,
   CFB: 24 * 60 * 60 * 1000,
   NBA: 12 * 60 * 60 * 1000,
-  MLB: 12 * 60 * 60 * 1000
+  MLB: 12 * 60 * 60 * 1000,
+  CBB: 12 * 60 * 60 * 1000
 };
 
 function getCacheKey(sport, season) {
@@ -341,9 +350,9 @@ export async function findLatestAvailable(sport, season) {
     return { week: currentWeek, fromCache: false };
   }
 
-  if (sport === 'NBA' || sport === 'MLB') {
+  if (sport === 'NBA' || sport === 'MLB' || sport === 'CBB') {
     const today = new Date();
-    const emoji = sport === 'NBA' ? '🏀' : '⚾';
+    const emoji = sport === 'NBA' ? '🏀' : sport === 'CBB' ? '🏀' : '⚾';
     console.log(`${emoji} ${sport}: Checking backwards from yesterday`);
 
     for (let daysAgo = 1; daysAgo <= 7; daysAgo++) {


### PR DESCRIPTION
## Summary\n- Add CBB as a new date-based sport (same pattern as NBA/MLB) with full algorithm config, ESPN API integration, and UI support\n- Add March Madness bracket view: a \"march madness\" link appears when CBB is selected, fetching all tournament games via ESPN's seasontype=3 endpoint\n- Bracket component renders games organized by round (R64 → Championship) with region groupings, seed display, GEI color-coding, and spoiler-free mode\n- Update `isDateBasedSport()` helper, calculator, data-quality, export modal, and all UI components for CBB support\n\n## Test plan\n- [ ] Select CBB in sport selector, verify date-based navigation works\n- [ ] Click \"march madness\" link, verify bracket loads with tournament games\n- [ ] Toggle spoiler-free mode in bracket view, verify scores/GEI hidden\n- [ ] Test bracket on mobile viewport (should stack vertically)\n- [ ] Verify export modal works for CBB with date-based presets\n\nhttps://claude.ai/code/session_01GNWjXrgVjhDr1ZVovb5owy